### PR TITLE
Fix Kiel country code, added Kreuzlingen, Regensburg

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -70,4 +70,6 @@ NL,Donkey Republic Rotterdam,Rotterdam,donkey_rt,https://www.donkey.bike/nl/sted
 NL,Donkey Republic Den Haag,Den Haag,donkey_den_haag,https://www.donkey.bike/cities/bike-rental-den-haag/,https://stables.donkey.bike/api/public/gbfs/donkey_den_haag/gbfs
 FR,Donkey Republic Brest,Brest,donkey_brest,https://www.donkey.bike/cities/bike-rental-brest/,https://stables.donkey.bike/api/public/gbfs/donkey_brest/gbfs
 DK,Donkey Republic Hillerød,Hillerød,donkey_hillerod,"",https://stables.donkey.bike/api/public/gbfs/donkey_hillerod/gbfs
-DK,Donkey Republic Kiel,Kiel,donkey_kiel,https://www.donkey.bike/cities/bike-rental-kiel/,https://stables.donkey.bike/api/public/gbfs/donkey_kiel/gbfs
+DE,Donkey Republic Kiel,Kiel,donkey_kiel,https://www.donkey.bike/cities/bike-rental-kiel/,https://stables.donkey.bike/api/public/gbfs/donkey_kiel/gbfs
+CH,Donkey Republic Kreuzlingen,Kreuzlingen,donkey_kreuzlingen,https://www.donkey.bike/cities/bike-rental-kreuzlingen/,https://stables.donkey.bike/api/public/gbfs/donkey_kreuzlingen/gbfs
+DE,Donkey Republic Regensburg,Regensburg,donkey_regensburg,https://www.donkey.bike/cities/bike-rental-regensburg/,https://stables.donkey.bike/api/public/gbfs/donkey_regensburg/gbfs


### PR DESCRIPTION
I also noted an outlier in the Kiel feed ("station_id":"24356", "name":"Hagen Bikes factory", "lat":59.4001397, "lon":24.8260731) which is in Estonia. Would be great if you could fix this.