### PR TITLE
Fix extra space in the feed URL of Ergolding

### DIFF
--- a/systems_v2.csv
+++ b/systems_v2.csv
@@ -7,7 +7,7 @@ ES,Donkey Barcelona,Barcelona,donkey_barcelona,https://www.donkey.bike/cities/bi
 DE,"Regensburg, Augsburg, Straubing, Tuttlingen","Augsburg, Regensburg, Tuttlingen ",donkey_regensburg,"",https://stables.donkey.bike/api/public/gbfs/2/donkey_regensburg/gbfs.json
 DE,Cham,Cham,Cham,"",https://stables.donkey.bike/api/public/gbfs/2/Cham/gbfs.json
 DE,Tuttlingen,Tuttlingen ,Tuttlingen,"",https://stables.donkey.bike/api/public/gbfs/2/Tuttlingen/gbfs.json
-DE,Ergolding,Ergolding,Ergolding ,"",https://stables.donkey.bike/api/public/gbfs/2/Ergolding /gbfs.json
+DE,Ergolding,Ergolding,Ergolding,"",https://stables.donkey.bike/api/public/gbfs/2/Ergolding/gbfs.json
 DE,Neutraubling,Neutraubling,Neutraubling,"",https://stables.donkey.bike/api/public/gbfs/2/Neutraubling/gbfs.json
 DE,Kelheim,Kelheim,Kelheim,"",https://stables.donkey.bike/api/public/gbfs/2/Kelheim/gbfs.json
 DE,Bamberg,Bamberg,Bamberg,"",https://stables.donkey.bike/api/public/gbfs/2/Bamberg/gbfs.json


### PR DESCRIPTION
This PR removes an extra space in the feed URL of Ergolding.